### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting function

### DIFF
--- a/src/build/helpers.ts
+++ b/src/build/helpers.ts
@@ -126,6 +126,9 @@ export function merge<T>(target: T, src: T, shallow?: boolean): T {
     throw new Error("Either `target` or `src` is null");
   }
   for (const k in src) {
+    if (k === "__proto__" || k === "constructor") {
+      continue;
+    }
     if (Object.getOwnPropertyDescriptor(src, k)) {
       if (Object.getOwnPropertyDescriptor(target, k)) {
         const targetProp = target[k];


### PR DESCRIPTION
Potential fix for [https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/6](https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/6)

To fix the issue, we need to explicitly block the special property names `__proto__` and `constructor` from being copied from `src` to `target`. This can be achieved by adding a condition to skip these keys during the iteration over `src`. This approach ensures that the function remains safe from prototype pollution while preserving its existing functionality.

The changes will be made in the `merge` function in `src/build/helpers.ts`:
1. Add a condition to skip keys `__proto__` and `constructor` during the iteration over `src`.
2. Ensure that this condition is applied before any operations involving the key `k`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
