### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-core-deps.yml
+++ b/.github/workflows/update-core-deps.yml
@@ -1,4 +1,7 @@
 name: Update core dependencies
+permissions:
+  contents: read
+  pull-requests: write
 on:
   workflow_dispatch: null
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/3](https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating pull requests using the `peter-evans/create-pull-request@v7` action.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
