### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -1,4 +1,6 @@
 name: Runs with TypeScript Tests
+permissions:
+  contents: read
 on:
   push:
     paths:
@@ -6,7 +8,6 @@ on:
   pull_request:
     paths:
       - "baselines/*"
-
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/2](https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's operations, it primarily needs `contents: read` to access repository contents. If additional permissions are required for specific steps (e.g., `pull-requests: write` for the `Danger` step), they can be added to the job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
