### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/1](https://github.com/melissamforbs/TypeScript-DOM-lib-generator/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs CI tasks (checking out the repository, setting up Node.js, installing dependencies, building, and running tests), it only requires `contents: read` permissions. This change ensures that the workflow has the minimum necessary permissions and avoids granting unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
